### PR TITLE
Use pre-commit-uv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: self test action
       uses: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
     - name: self test action
       uses: ./

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ ___
 pre-commit/action
 =================
 
-a GitHub action to run [pre-commit](https://pre-commit.com)
+A GitHub action to run [pre-commit](https://pre-commit.com)
+using [pre-commit-uv](https://github.com/tox-dev/pre-commit-uv).
 
 ### using this action
 
@@ -31,15 +32,14 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@v4
+    - uses: tox-dev/action-pre-commit-uv@v1
 ```
 
 This does a few things:
 
 - clones the code
-- installs python
+- installs uv
 - sets up the `pre-commit` cache
 
 ### using this action with custom invocations
@@ -51,7 +51,7 @@ Here's a sample step configuration that only runs the `flake8` hook against all
 the files (use the template above except for the `pre-commit` action):
 
 ```yaml
-    - uses: pre-commit/action@v3.0.1
+    - uses: tox-dev/action-pre-commit-uv@v1
       with:
         extra_args: flake8 --all-files
 ```

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,10 @@ inputs:
 runs:
   using: composite
   steps:
-  - run: python -m pip install pre-commit
-    shell: bash
-  - run: python -m pip freeze --local
-    shell: bash
+  - uses: hynek/setup-cached-uv@v2
   - uses: actions/cache@v4
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-  - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+  - run: uv run --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash


### PR DESCRIPTION
Using pre-commit-uv on GitHub Actions cuts about 20 seconds from the run, compared with regular pre-commit.

For example, 1m 5s -> 44s when no cache: https://github.com/hugovk/norwegianblue/pull/224

It also simplifies the workflow because uvx takes care of installing Python for us as well:

```diff
diff --git a/.github/workflows/lint.yml b/.github/workflows/lint.yml
index d553e49..07430cb 100644
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -15,8 +14,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: hugovk/pre-commit-action-uv@v3.0.1

```
