### PR TITLE
Use `uvx` instead uv `uv run --no-sync` to run `pre-commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 This does a few things:
 
 - clones the code
-- installs uv
+- installs `uv`
 - sets up the `pre-commit` cache
 
 ### using this action with custom invocations
@@ -54,6 +54,29 @@ the files (use the template above except for the `pre-commit` action):
     - uses: tox-dev/action-pre-commit-uv@v1
       with:
         extra_args: flake8 --all-files
+```
+
+### using a specific version of `uv`
+
+By default, the latest version of `uv` is installed.
+If this is not desired, a specific version can be requested using the `uv_version` input:
+
+```yaml
+    - uses: tox-dev/action-pre-commit-uv@v1
+      with:
+        uv_version: "0.8.5"
+```
+
+```yaml
+    - uses: tox-dev/action-pre-commit-uv@v1
+      with:
+        uv_version: "0.8.x"
+```
+
+```yaml
+    - uses: tox-dev/action-pre-commit-uv@v1
+      with:
+        uv_version: ">=0.8,<9"
 ```
 
 ### using this action in private repositories

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ runs:
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-  - run: uv run --no-sync --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+  - run: uvx --python '${{ env.pythonLocation }}' --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
   - name: Install the latest version of uv
-    uses: astral-sh/setup-uv@v5
+    uses: astral-sh/setup-uv@v6
     with:
       enable-cache: true
       cache-dependency-glob: '.pre-commit-config.yaml'

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: options to pass to pre-commit run
     required: false
     default: '--all-files'
+  uv_version:
+    description: use a specific version of uv (default latest)
+    required: false
+    default: latest
 runs:
   using: composite
   steps:
@@ -13,6 +17,7 @@ runs:
     with:
       enable-cache: true
       cache-dependency-glob: '.pre-commit-config.yaml'
+      uv-version: ${{ inputs.uv_version }}
   - run: uv run --isolated --no-sync true && echo "pythonLocation=$(uv python find)" >>$GITHUB_ENV
     shell: bash
   - uses: actions/cache@v4


### PR DESCRIPTION
This solves a regression in `uv` that makes the action fail on `uv>0.8.1` (currently the latest version is 0.8.6).
Also this fixes #6.