### PR TITLE
Autoupdate pre-commit quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,6 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
Closes https://github.com/tox-dev/action-pre-commit-uv/pull/11.

Let's automate so we don't need manual PRs such as the above. Quarterly should be enough here, rather than the default weekly.

@gaborbernat Please could you turn on https://pre-commit.ci/ for this repo?

I think https://github.com/apps/pre-commit-ci/installations/12624925 might be the shortcut, I didn't have permission to do it.