### PR TITLE
🐛 fix(action): skip uv install when already present

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,12 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Check if uv is already installed
+    id: check-uv
+    run: command -v uv && echo "installed=true" >> "$GITHUB_OUTPUT" || echo "installed=false" >> "$GITHUB_OUTPUT"
+    shell: bash
   - name: Install the latest version of uv
+    if: steps.check-uv.outputs.installed != 'true'
     uses: astral-sh/setup-uv@v7
     with:
       enable-cache: true


### PR DESCRIPTION
Users who already run `setup-uv` earlier in their workflow get a redundant second installation when this action unconditionally calls `setup-uv` again. This wastes CI time downloading and setting up uv twice, as reported in #7.

The action now checks whether `uv` is already on `PATH` before running the `setup-uv` step. 🔧 If uv is detected, the install step is skipped entirely. This keeps the action fully self-contained for standalone use — when no prior `setup-uv` exists, it installs uv as before — while avoiding duplicate work in combined workflows.

Note: the comments on #7 also mention that the `pre-commit-uv` Python package itself declares `uv` as a dependency, causing yet another download inside the `--with` environment. That's a separate concern in the `pre-commit-uv` package, not this action.

Closes #7