### PR TITLE
✨ feat(action): add uv-install input and auto-detect uvx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,26 @@ permissions:
   contents: read
 
 jobs:
-  main:
+  main-uvx:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: self test action
+    - name: self test action (uvx path)
       uses: ./
+  main-uv-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - run: printf '[project]\nname = "test"\nversion = "0.0.0"\nrequires-python = ">=3.13"\n' > pyproject.toml
+      shell: bash
+    - name: self test action (uv run path)
+      uses: ./
+  main-external-uv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+    - name: self test action (external uv)
+      uses: ./
+      with:
+        uv-install: 'false'

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/tox-dev/action-pre-commit-uv/main.svg)](https://results.pre-commit.ci/latest/github/tox-dev/action-pre-commit-uv/main)
 [![Build Status](https://github.com/tox-dev/action-pre-commit-uv/actions/workflows/main.yml/badge.svg)](https://github.com/tox-dev/action-pre-commit-uv/actions)
 
-tox-dev/action-pre-commit-uv
-============================
+# tox-dev/action-pre-commit-uv
 
-A GitHub action to run [pre-commit](https://pre-commit.com)
-using [pre-commit-uv](https://github.com/tox-dev/pre-commit-uv).
+A GitHub action to run [pre-commit](https://pre-commit.com) using
+[pre-commit-uv](https://github.com/tox-dev/pre-commit-uv).
 
 ### using this action
 
-To use this action, make a file `.github/workflows/pre-commit.yml`.  Here's a
-template to get started:
+To use this action, make a file `.github/workflows/pre-commit.yml`. Here's a template to get started:
 
 ```yaml
 name: pre-commit
@@ -24,52 +22,67 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: tox-dev/action-pre-commit-uv@v1
+      - uses: actions/checkout@v4
+      - uses: tox-dev/action-pre-commit-uv@v1
 ```
 
 This does a few things:
 
 - clones the code
-- installs uv
+- installs uv (if not already available)
 - sets up the `pre-commit` cache
+
+The action auto-detects the right invocation: if a `pyproject.toml` exists it uses `uv run`, otherwise it uses `uvx` for
+isolated tool execution.
+
+### controlling uv installation
+
+By default (`uv-install: 'auto'`), the action detects whether uv is already available and only installs it if needed.
+You can override this with `'true'` (always install) or `'false'` (never install):
+
+```yaml
+  - uses: astral-sh/setup-uv@v7
+    with:
+      version: 0.6.0
+  - uses: tox-dev/action-pre-commit-uv@v1
+    with:
+      uv-install: 'false'
+```
 
 ### using this action with custom invocations
 
-By default, this action runs all the hooks against all the files.  `extra_args`
-lets users specify a single hook id and/or options to pass to `pre-commit run`.
+By default, this action runs all the hooks against all the files. `extra_args` lets users specify a single hook id
+and/or options to pass to `pre-commit run`.
 
-Here's a sample step configuration that only runs the `flake8` hook against all
-the files (use the template above except for the `pre-commit` action):
+Here's a sample step configuration that only runs the `flake8` hook against all the files (use the template above except
+for the `pre-commit` action):
 
 ```yaml
-    - uses: tox-dev/action-pre-commit-uv@v1
-      with:
-        extra_args: flake8 --all-files
+  - uses: tox-dev/action-pre-commit-uv@v1
+    with:
+      extra_args: flake8 --all-files
 ```
 
 ### using this action in private repositories
 
-prior to v3.0.0, this action had custom behaviour which pushed changes back to
-the pull request when supplied with a `token`.
+prior to v3.0.0, this action had custom behaviour which pushed changes back to the pull request when supplied with a
+`token`.
 
 this behaviour was removed:
+
 - it required a PAT (didn't work with short-lived `GITHUB_TOKEN`)
-- properly hiding this `input` from the installation and execution of hooks
-  is intractable in github actions (it is readily available as `$INPUT_TOKEN`)
-- this meant potentially unvetted code could access the token via the
-  environment
+- properly hiding this `input` from the installation and execution of hooks is intractable in github actions (it is
+  readily available as `$INPUT_TOKEN`)
+- this meant potentially unvetted code could access the token via the environment
 
-you can _likely_ achieve the same thing with an external action such as
-[git-auto-commit-action] though you may want to take precautions to clear `git`
-hooks or other ways that arbitrary code execution can occur when running
-`git commit` / `git push` (for example [core.fsmonitor]).
+you can _likely_ achieve the same thing with an external action such as [git-auto-commit-action] though you may want to
+take precautions to clear `git` hooks or other ways that arbitrary code execution can occur when running `git commit` /
+`git push` (for example [core.fsmonitor]).
 
-while unrelated to this action, [pre-commit.ci] avoids these problems by
-installing and executing isolated from the short-lived repository-scoped
-[installation access token].
+while unrelated to this action, [pre-commit.ci] avoids these problems by installing and executing isolated from the
+short-lived repository-scoped [installation access token].
 
-[git-auto-commit-action]: https://github.com/stefanzweifel/git-auto-commit-action
 [core.fsmonitor]: https://github.blog/2022-04-12-git-security-vulnerability-announced/
-[pre-commit.ci]: https://pre-commit.ci
+[git-auto-commit-action]: https://github.com/stefanzweifel/git-auto-commit-action
 [installation access token]: https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app
+[pre-commit.ci]: https://pre-commit.ci

--- a/action.yml
+++ b/action.yml
@@ -5,15 +5,20 @@ inputs:
     description: options to pass to pre-commit run
     required: false
     default: '--all-files'
+  uv-install:
+    description: whether to install uv (true=always, false=never, auto=only if not already available)
+    required: false
+    default: 'auto'
 runs:
   using: composite
   steps:
   - name: Check if uv is already installed
+    if: inputs.uv-install == 'auto'
     id: check-uv
     run: command -v uv && echo "installed=true" >> "$GITHUB_OUTPUT" || echo "installed=false" >> "$GITHUB_OUTPUT"
     shell: bash
   - name: Install the latest version of uv
-    if: steps.check-uv.outputs.installed != 'true'
+    if: inputs.uv-install == 'true' || (inputs.uv-install == 'auto' && steps.check-uv.outputs.installed != 'true')
     uses: astral-sh/setup-uv@v7
     with:
       enable-cache: true
@@ -24,5 +29,10 @@ runs:
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-  - run: uv run --no-sync --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+  - run: |
+      if [ -f pyproject.toml ]; then
+        uv run --no-sync --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+      else
+        uvx --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+      fi
     shell: bash


### PR DESCRIPTION
The action always hardcoded `uv run` regardless of whether a `pyproject.toml` existed, which is semantically wrong — `uvx` is the right tool for running standalone tools without a project context. Users who already configured uv externally (with a specific Python version, caching, etc.) also had no way to skip the redundant `setup-uv` step.

✨ A new `uv-install` input controls uv installation with three modes: `'auto'` (default) detects whether uv is already available and skips installation if so, `'true'` always installs, and `'false'` never installs. The run step now auto-detects whether to use `uv run` or `uvx` based on `pyproject.toml` presence, so repos without a project file get the correct isolated tool execution.

This is fully backward compatible — the `'auto'` default preserves existing behavior, and the `pyproject.toml` detection matches what was already implicitly happening.

Closes #6