### PR TITLE
🐛 fix(ci): unbreak pre-commit and finish zizmor lockdown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,5 @@ updates:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:
@@ -7,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  main-uvx:
+  self-test-uvx:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -15,7 +17,7 @@ jobs:
         persist-credentials: false
     - name: self test action (uvx path)
       uses: ./
-  main-uv-run:
+  self-test-uv-run:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -25,7 +27,7 @@ jobs:
       shell: bash
     - name: self test action (uv run path)
       uses: ./
-  main-external-uv:
+  self-test-external-uv:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.23.1
     hooks:

--- a/action.yml
+++ b/action.yml
@@ -19,20 +19,22 @@ runs:
     shell: bash
   - name: Install the latest version of uv
     if: inputs.uv-install == 'true' || (inputs.uv-install == 'auto' && steps.check-uv.outputs.installed != 'true')
-    uses: astral-sh/setup-uv@v7
+    uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
     with:
       enable-cache: true
       cache-dependency-glob: '.pre-commit-config.yaml'
   - run: uv run --isolated --no-sync true && echo "pythonLocation=$(uv python find)" >>$GITHUB_ENV
     shell: bash
-  - uses: actions/cache@v5
+  - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: |
       if [ -f pyproject.toml ]; then
-        uv run --no-sync --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+        uv run --no-sync --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${INPUTS_EXTRA_ARGS}
       else
-        uvx --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+        uvx --with pre-commit-uv pre-commit run --show-diff-on-failure --color=always ${INPUTS_EXTRA_ARGS}
       fi
     shell: bash
+    env:
+      INPUTS_EXTRA_ARGS: ${{ inputs.extra_args }}


### PR DESCRIPTION
CI on `main` is red for every job because the `zizmor` hook added in #25 cannot parse `.pre-commit-config.yaml`. The file mixes 2- and 4-space list indentation, so pre-commit aborts with `InvalidConfigError` before any hook runs. 🔧

#25 also enabled `zizmor` without running it against `action.yml` or `.github/dependabot.yaml`, which carry five real findings: `astral-sh/setup-uv` and `actions/cache` are referenced by floating tag rather than commit SHA, `${{ inputs.extra_args }}` is interpolated directly into a `run:` block (template injection), and the Dependabot config has no `cooldown`. Pinning to SHAs matches the policy already applied in `.github/workflows/main.yml`. Moving `inputs.extra_args` into the step's `env:` and referencing it as `${INPUTS_EXTRA_ARGS}` removes the injection path while preserving word splitting, so callers passing multiple flags keep working.

The workflow jobs are also renamed from `main-*` to `self-test-*` and the workflow gains a top-level `name: CI`, so PR status checks read as `CI / self-test-uvx` instead of `main / main-uvx`. ✨