### PR TITLE
👷 ci: auto-update floating major/minor tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Update floating tags
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Full version tag to point the floating tags at (e.g. v1.0.4)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-floating-tags:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    permissions:
+      contents: write
+    steps:
+    - name: Move major and minor tags to the released version
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      run: |
+        set -euo pipefail
+        if [[ ! "${TAG}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+          echo "::error::Unexpected tag format: ${TAG} (expected vMAJOR.MINOR.PATCH)" >&2
+          exit 1
+        fi
+        major="v${BASH_REMATCH[1]}"
+        minor="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        sha="$(gh api "repos/${REPO}/commits/${TAG}" --jq '.sha')"
+        for ref in "${major}" "${minor}"; do
+          if gh api "repos/${REPO}/git/refs/tags/${ref}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/tags/${ref}" -f "sha=${sha}" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/git/refs" -f "ref=refs/tags/${ref}" -f "sha=${sha}" >/dev/null
+          fi
+          echo "Pointed ${ref} -> ${TAG} (${sha})"
+        done


### PR DESCRIPTION
Users pinning `tox-dev/action-pre-commit-uv@v1`, as the README recommends, were running stale code. 🏷️ The `v1` tag on the remote points to `v1.0.0` while `v1.0.4` is the current release, because nothing re-points the floating tag once a new version ships. Issue #28 reported this drift.

The chosen direction keeps the `v1` and `v1.0` floating tags so existing consumers stay unaffected, and instead automates their maintenance. A new `Update floating tags` workflow runs whenever a stable release is published, deriving `vX` and `vX.Y` from the released `vX.Y.Z` and re-pointing them through the GitHub REST API. ✨ Working through the API means no checkout and no persisted credentials, which keeps the workflow clean under the repo's `zizmor` audit; `contents: write` is scoped to the single job while the top level stays read-only. Prereleases are skipped, and a `workflow_dispatch` input allows pointing the tags at an explicit version on demand.

To repair the current drift after merge, run the workflow once with `tag = v1.0.4`; this moves `v1` forward and creates the missing `v1.0`. A malformed `1.0.3` tag (missing the `v` prefix, off `main`) also exists and can be deleted separately, but is left untouched here.

Closes #28.