### PR TITLE
🐛 ci: detect floating tags via exact ref endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         minor="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
         sha="$(gh api "repos/${REPO}/commits/${TAG}" --jq '.sha')"
         for ref in "${major}" "${minor}"; do
-          if gh api "repos/${REPO}/git/refs/tags/${ref}" >/dev/null 2>&1; then
+          if gh api "repos/${REPO}/git/ref/tags/${ref}" >/dev/null 2>&1; then
             gh api -X PATCH "repos/${REPO}/git/refs/tags/${ref}" -f "sha=${sha}" -F force=true >/dev/null
           else
             gh api -X POST "repos/${REPO}/git/refs" -f "ref=refs/tags/${ref}" -f "sha=${sha}" >/dev/null


### PR DESCRIPTION
The floating-tag workflow added in #29 moved `v1` correctly but failed to create `v1.0`, exiting with HTTP 422. 🐛 The existence check queried `git/refs/tags/<ref>`, the plural list endpoint, which prefix-matches: `tags/v1.0` matched the existing `v1.0.x` releases, so the script believed `v1.0` already existed and tried to `PATCH` a ref that was never there.

Switching the check to the singular `git/ref/tags/<ref>` endpoint makes it exact: an absent floating tag returns 404, so the script falls through to creating it. `v1` already points at `v1.0.4` from the first dispatch; re-running after this merge will create the missing `v1.0`.